### PR TITLE
properly escape underscores

### DIFF
--- a/lib/helpers.js
+++ b/lib/helpers.js
@@ -209,7 +209,9 @@ function orderPRsByRepo (prs) {
       const link = formatForMsTeams
         ? `[${pr.number}](${pr.html_url})`
         : `<${pr.html_url}|${pr.number}>`
-      return `‣ ${pr.user.login} ☞ ${assignees} ${link}: ${pr.title}`
+      // escape underscores, otherwise everything become italics until the next
+      // underscore
+      return `‣ ${pr.user.login} ☞ ${assignees} ${link}: ${pr.title.replace('_', '\\_')}`
     }).sort()
     messages.push(...prMessages)
   })

--- a/lib/helpers.js
+++ b/lib/helpers.js
@@ -209,8 +209,6 @@ function orderPRsByRepo (prs) {
       const link = formatForMsTeams
         ? `[${pr.number}](${pr.html_url})`
         : `<${pr.html_url}|${pr.number}>`
-      // escape underscores, otherwise everything become italics until the next
-      // underscore
       return `‣ ${pr.user.login} ☞ ${assignees} ${link}: ${pr.title}`
     }).sort()
     messages.push(...prMessages)

--- a/lib/helpers.js
+++ b/lib/helpers.js
@@ -211,7 +211,7 @@ function orderPRsByRepo (prs) {
         : `<${pr.html_url}|${pr.number}>`
       // escape underscores, otherwise everything become italics until the next
       // underscore
-      return `‣ ${pr.user.login} ☞ ${assignees} ${link}: ${pr.title.replace('_', '\\_')}`
+      return `‣ ${pr.user.login} ☞ ${assignees} ${link}: ${pr.title}`
     }).sort()
     messages.push(...prMessages)
   })

--- a/lib/ms-teams.js
+++ b/lib/ms-teams.js
@@ -25,7 +25,7 @@ module.exports.notifyMsTeams = function notifyMSTeams (text) {
         '@type': 'MessageCard',
         themeColor: '0072C6',
         title: `git-it-together report for ${moment().format('YYYY-MM-DD')}`,
-        text: text.replace('_', '\\_'),
+        text: text.replace(/_/g, '\\_'),
         potentialAction: []
       })
     }

--- a/lib/ms-teams.js
+++ b/lib/ms-teams.js
@@ -25,6 +25,8 @@ module.exports.notifyMsTeams = function notifyMSTeams (text) {
         '@type': 'MessageCard',
         themeColor: '0072C6',
         title: `git-it-together report for ${moment().format('YYYY-MM-DD')}`,
+        // escape underscores, otherwise everything become italics until the next
+        // underscore
         text: text.replace(/_/g, '\\_'),
         potentialAction: []
       })


### PR DESCRIPTION
This PR contains code to properly escape underscores in PR titles as they will cause the rest of the text to become italicized in MS Teams markdown until another underscore is reached.