### PR TITLE
Ensure Teams Messages are Always Posted

### DIFF
--- a/lib/ms-teams.js
+++ b/lib/ms-teams.js
@@ -25,7 +25,7 @@ module.exports.notifyMsTeams = function notifyMSTeams (text) {
         '@type': 'MessageCard',
         themeColor: '0072C6',
         title: `git-it-together report for ${moment().format('YYYY-MM-DD')}`,
-        text: text.replace('_', '\\_'),
+        text: text.replace('_', '\\_').slice(-10_000),
         potentialAction: []
       })
     }


### PR DESCRIPTION
The teams messages can sometimes get too large for teams to accept. This PR ensures that only the last 10,000 characters are sent. Sometimes messages get cut off, but the most important part (the last bit with the count) is always shown.